### PR TITLE
removed chapter.id in favour of chapter.name

### DIFF
--- a/src/hooks/useLichessStudy.ts
+++ b/src/hooks/useLichessStudy.ts
@@ -41,14 +41,14 @@ const useLichessStudy = () => {
   }, [lichessUser]);
 
   const importPgn = (chapter: IChapter) => {
-    if (chapter.chapterId) {
+    if (chapter.name) {
       const headers = getHeaders(chapter.pgn);
       gameDispatch({
         type: "SET_GAME",
         payload: { pgn: chapter.pgn, headers: headers },
       });
       toast.success(`${chapter.name} imported successfully`, {
-        toastId: `${chapter.chapterId}-lichess-import-success`,
+        toastId: `${chapter.name}-lichess-import-success`,
       });
     }
   };


### PR DESCRIPTION
- Removed conditional loading of gamer based on `chapter.id`, now using `chapter.name`
- `lichess.ts` still returns `chapterId` until after i study any changes to the lichess API and what is exported in game headers